### PR TITLE
Export the find function directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,26 +5,28 @@ Correctly identifies cards from VISA, Amex, Mastercard, Diners, Discover, JCB, S
 Interface
 -----
 ```js
-ccId.find('card number');
+identifyCard('card number');
 ```
 Given a card number represented as a string, the find method will return the name of the card scheme or 'Unknown'.
+
 Usage
 -----
 ```js
-ccId = require('credit-card-identifier')
+identifyCard = require('credit-card-identifier')
 
-console.log(ccId.find('4929255008802878')) //VISA
-console.log(ccId.find('4532971714778876')) //VISA
+console.log(identifyCard('4929255008802878')) //VISA
+console.log(identifyCard('4532971714778876')) //VISA
 
-console.log(ccId.find('5170651768364146')) //MasterCard
-console.log(ccId.find('5125796296825872')) //MasterCard
+console.log(identifyCard('5170651768364146')) //MasterCard
+console.log(identifyCard('5125796296825872')) //MasterCard
 
-console.log(ccId.find('349237692562216')) //AMEX
-console.log(ccId.find('375886564589009')) //AMEX
+console.log(identifyCard('349237692562216')) //AMEX
+console.log(identifyCard('375886564589009')) //AMEX
 
-console.log(ccId.find('3011286804723969')) //Diners
-console.log(ccId.find('3026210028069895')) //Diners
+console.log(identifyCard('3011286804723969')) //Diners
+console.log(identifyCard('3026210028069895')) //Diners
 ```
+
 Contributing
 ------------
 All contributions are welcome. 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,13 +12,13 @@ var identifiers = [
 	{name:'Maestro', pattern:/^(5[06-8]|6\d)\d{10,17}$/},
 	{name:'Forbrugsforeningen', pattern:/^600722\d{10}$/},
 	{name:'Laser', pattern:/^(6304|6706|6771|6709)\d{8}(\d{4}|\d{6,7})?$/},
-	{name:'Unknown', pattern:/.*/},
+	{name:'Unknown', pattern:/.*/}
 ]
 
-module.exports.find = function(pan){
+module.exports = function(pan){
 	for(var i = 0; i < identifiers.length; i++){
 		var scheme = identifiers[i];
 		if(scheme.pattern.test(pan))
-			return scheme.name
+			return scheme.name;
 	}
-}
+};

--- a/test/card-test.js
+++ b/test/card-test.js
@@ -1,20 +1,20 @@
 var should = require('should');
-var ccId = require('../lib');
+var identifyCard = require('../lib');
 
 describe("Credit Card Identifier can identify", function(){
 	it("Visa", function(){
-		ccId.find('4929255008802878').should.eql('VISA')
-		ccId.find('4532971714778876').should.eql('VISA')
+		identifyCard('4929255008802878').should.eql('VISA')
+		identifyCard('4532971714778876').should.eql('VISA')
 	})
 
 	it("MasterCard", function(){
-		ccId.find('5170651768364146').should.eql('MasterCard')
-		ccId.find('5125796296825872').should.eql('MasterCard')
+		identifyCard('5170651768364146').should.eql('MasterCard')
+		identifyCard('5125796296825872').should.eql('MasterCard')
 	})
 
 	it("Amex", function(){
-		ccId.find('349237692562216').should.eql('Amex')
-		ccId.find('375886564589009').should.eql('Amex')
+		identifyCard('349237692562216').should.eql('Amex')
+		identifyCard('375886564589009').should.eql('Amex')
 	})
 
 })


### PR DESCRIPTION
If the output of a module is only a function, it's idiomatic in node to export it directly using `module.exports` rather than hanging it off of an otherwise-empty object literal.

Updated code, tests, and README.

Please forgive the opinionated pull-request :)

Reference: http://stackoverflow.com/questions/17936515/best-practice-for-structuring-libraries-to-be-required-in-node-js though there are others if you google "substack pattern"
