### PR TITLE
Updated ChinaUnionPay/Discover Regex

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,12 @@
+
+'use strict';
+
 //Regular expressions are from http://activemerchant.rubyforge.org/classes/ActiveMerchant/Billing/CreditCardMethods.html
+
 var identifiers = [
 	{name:'VISA', pattern:/^4\d{12}(\d{3})?$/},
 	{name:'MasterCard', pattern:/^(5[1-5]\d{4}|677189)\d{10}$/},
+  {name:'Discover', pattern:/^6(?:011\d\d|5\d{4}|4[4-9]\d{3}|22(?:1(?:2[6-9]|[3-9]\d)|[2-8]\d\d|9(?:[01]\d|2[0-5])))\d{10}$/},
 	{name:'Discover', pattern:/^(6011|65\d{2})\d{12}$/},
 	{name:'Amex', pattern:/^3[47]\d{13}$/},
 	{name:'Diners', pattern:/^3(0[0-5]|[68]\d)\d{11}$/},
@@ -16,7 +21,7 @@ var identifiers = [
 ]
 
 module.exports = function(pan){
-	for(var i = 0; i < identifiers.length; i++){
+	for(var i = 0; i < identifiers.length; i++) {
 		var scheme = identifiers[i];
 		if(scheme.pattern.test(pan))
 			return scheme.name;

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,6 @@ var identifiers = [
 	{name:'VISA', pattern:/^4\d{12}(\d{3})?$/},
 	{name:'MasterCard', pattern:/^(5[1-5]\d{4}|677189)\d{10}$/},
   {name:'Discover', pattern:/^6(?:011\d\d|5\d{4}|4[4-9]\d{3}|22(?:1(?:2[6-9]|[3-9]\d)|[2-8]\d\d|9(?:[01]\d|2[0-5])))\d{10}$/},
-	{name:'Discover', pattern:/^(6011|65\d{2})\d{12}$/},
 	{name:'Amex', pattern:/^3[47]\d{13}$/},
 	{name:'Diners', pattern:/^3(0[0-5]|[68]\d)\d{11}$/},
 	{name:'JCB', pattern:/^35(28|29|[3-8]\d)\d{12}$/},

--- a/test/card-test.js
+++ b/test/card-test.js
@@ -1,24 +1,30 @@
+
+'use strict';
+
+// Example test cards: http://support.worldpay.com/support/kb/bg/testandgolive/tgl5103.html
+
 var should = require('should');
 var identifyCard = require('../lib');
 
-describe("Credit Card Identifier can identify", function(){
+describe("Credit Card Identifier can identify", function() {
 	it("Visa", function(){
 		identifyCard('4929255008802878').should.eql('VISA')
 		identifyCard('4532971714778876').should.eql('VISA')
-	})
+	});
 
 	it("MasterCard", function(){
 		identifyCard('5170651768364146').should.eql('MasterCard')
 		identifyCard('5125796296825872').should.eql('MasterCard')
-	})
+	});
 
 	it("Amex", function(){
 		identifyCard('349237692562216').should.eql('Amex')
 		identifyCard('375886564589009').should.eql('Amex')
-	})
+	});
 
-})
-
-
-
+  it('Discover', function() {
+    identifyCard('6011111111111117').should.eql('Discover');
+    identifyCard('6221261111113245').should.eql('Discover');
+  });
+});
 

--- a/test/card-test.js
+++ b/test/card-test.js
@@ -26,5 +26,9 @@ describe("Credit Card Identifier can identify", function() {
     identifyCard('6011111111111117').should.eql('Discover');
     identifyCard('6221261111113245').should.eql('Discover');
   });
+
+  it('Maestro', function() {
+    identifyCard('6799990100000000019').should.eql('Maestro');
+  });
 });
 


### PR DESCRIPTION
Updated the Discover Regex. The old one did not include China Union Pay, which is part of Discover now. 

The following is taken from: http://www.richardsramblings.com/regex/credit-card-numbers/

> Discover Card
> 
> The first six digits of any credit or debit card identify the issuing authority or bank. According to the Discover Network’s developer documentation, Discover Card’s issuer identification numbers start with 6011, 622126-622925 (Discover cards in this range are dual-branded with UnionPay), 644-649, or 65.
> 
> Not as intuitively simple as VISA or MasterCard regexes due to the full-length IINs, an input-validation regex for 16-digit Discover card numbers needs to account for the range of six-digit issuer identifiers. No spaces or dashes are allowed, e.g. “6011000990139424″.
> ^6(?:011\d\d|5\d{4}|4[4-9]\d{3}|22(?:1(?:2[6-9]|[3-9]\d)|[2-8]\d\d|9(?:[01]\d|2[0-5])))\d{10}$
